### PR TITLE
Upgraded deep java library to enable Hugging Face Token

### DIFF
--- a/java/apirag-bedrock/pom.xml
+++ b/java/apirag-bedrock/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>ai.djl.huggingface</groupId>
       <artifactId>tokenizers</artifactId>
-      <version>${huggingface.version}</version>
+      <version>${djl.version}</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/java/apirag-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockChatModel.java
+++ b/java/apirag-bedrock/src/main/java/com/datasqrl/ai/models/bedrock/BedrockChatModel.java
@@ -8,11 +8,7 @@ import lombok.Getter;
 @Getter
 public enum BedrockChatModel implements GenericLanguageModel {
 
-  //  Tokenizers are not openly downloadable for these models yet, as they need a HuggingFace Access Token.
-//  In the next release of ai.djl.huggingface, the Hugging Face access token is read from the local environment.
-//  Until then, we can use the llama3-7b tokenizer as a temporary solution, as the tokenizer is currently only used to
-//  prevent context window overflow
-  LLAMA3_70B("meta.llama3-70b-instruct-v1:0", "meta-llama/Meta-Llama-3-8B-Instruct", 8192, 1024),
+  LLAMA3_70B("meta.llama3-70b-instruct-v1:0", "meta-llama/Meta-Llama-3-70B-Instruct", 8192, 1024),
   LLAMA3_8B("meta.llama3-8b-instruct-v1:0", "meta-llama/Meta-Llama-3-8B-Instruct", 8192, 512);
 
   final String modelName;

--- a/java/apirag-groq/pom.xml
+++ b/java/apirag-groq/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>ai.djl.huggingface</groupId>
       <artifactId>tokenizers</artifactId>
-      <version>${huggingface.version}</version>
+      <version>${djl.version}</version>
     </dependency>
   </dependencies>
 

--- a/java/apirag-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatModel.java
+++ b/java/apirag-groq/src/main/java/com/datasqrl/ai/models/groq/GroqChatModel.java
@@ -8,16 +8,9 @@ import lombok.Getter;
 @Getter
 public enum GroqChatModel implements GenericLanguageModel {
 
-//  Tokenizers are not openly downloadable for these models yet, as they need a HuggingFace Access Token.
-//  In the next release of ai.djl.huggingface, the Hugging Face access token is read from the local environment.
-//  Until then, we can use the llama3-7b tokenizer as a temporary solution, as the tokenizer is currently only used to
-//  prevent context window overflow
-//  LLAMA3_70B("llama3-70b-8192", "meta-llama/Meta-Llama-3-70B-Instruct", 8192, 512),
-//  MIXTRAL_8x7B("mixtral-8x7b-32768", "mistralai/Mixtral-8x7B-Instruct-v0.1", 32768, 512),
-//  GEMMA_7B("gemma-7b-it", "google/gemma-1.1-7b-it", 8192, 512),
-  LLAMA3_70B("llama3-70b-8192", "meta-llama/Meta-Llama-3-8B-Instruct", 8192, 1024),
-  MIXTRAL_8x7B("mixtral-8x7b-32768", "meta-llama/Meta-Llama-3-8B-Instruct", 32768, 512),
-  GEMMA_7B("gemma-7b-it", "meta-llama/Meta-Llama-3-8B-Instruct", 8192, 512),
+  LLAMA3_70B("llama3-70b-8192", "meta-llama/Meta-Llama-3-70B-Instruct", 8192, 512),
+  MIXTRAL_8x7B("mixtral-8x7b-32768", "mistralai/Mixtral-8x7B-Instruct-v0.1", 32768, 512),
+  GEMMA_7B("gemma-7b-it", "google/gemma-1.1-7b-it", 8192, 512),
   LLAMA3_7B("llama3-8b-8192", "meta-llama/Meta-Llama-3-8B-Instruct", 8192, 512);
 
   final String modelName;

--- a/java/apirag-openai/pom.xml
+++ b/java/apirag-openai/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>ai.djl.huggingface</groupId>
       <artifactId>tokenizers</artifactId>
-      <version>${huggingface.version}</version>
+      <version>${djl.version}</version>
     </dependency>
   </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,7 +23,7 @@
     <junit.jupiter.version>5.8.2</junit.jupiter.version>
     <lombok.version>1.18.24</lombok.version>
     <jackson.version>2.17.1</jackson.version>
-    <huggingface.version>0.27.0</huggingface.version>
+    <djl.version>0.28.0</djl.version>
     <autservice.version>1.1.1</autservice.version>
     <commons-config.version>2.10.1</commons-config.version>
     <commons-beanutil.version>1.9.4</commons-beanutil.version>


### PR DESCRIPTION
### Usage
In order to access some tokenizers from Hugging Face, as a user, you need accept their usage terms. This is verified by an access token you can download from their website.
1. Head over to your model tokenizer, like https://huggingface.co/meta-llama/Meta-Llama-3-70B-Instruct , log in and accept their terms.
2. Go to https://huggingface.co/settings/tokens and donwload your access token
3. Add it to your environment as HF_TOKEN=XXXX
4. Run apiRag with Bedrock or Groq and Llam3 70B

Note: For the other groq tokenizers to work as well, you need to accept the terms for these models as well:
- https://huggingface.co/google/gemma-1.1-7b-it
- https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1